### PR TITLE
White stars instead of gray - minor graphical improvement

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,7 +22,7 @@ renderer.render(scene, camera);
 // Torus
 
 const geometry = new THREE.TorusGeometry(10, 3, 16, 100);
-const material = new THREE.MeshStandardMaterial({ color: 0xff6347 });
+const material = new THREE.MeshBasicMaterial({ color: 0xff6347 });
 const torus = new THREE.Mesh(geometry, material);
 
 scene.add(torus);


### PR DESCRIPTION
Changed material in function addStar() from MeshStandardMaterial to MeshBasicMaterial to let stars shine white instead of grey (for some versions of three.js).